### PR TITLE
Changed Mobile Staff delegation logic

### DIFF
--- a/app/views/hq_fo_ccs_view.py
+++ b/app/views/hq_fo_ccs_view.py
@@ -23,7 +23,7 @@ def get_employee_tabs(employee_information, current_job_role, device_information
                          'ONS Mobile Number': device_number
                          }
 
-    if employee_information['mobileStaff']:
+    if employee_information[4:7] == "MOB":
         mobile_staff = 'Yes'
     else:
         mobile_staff = 'No'

--- a/app/views/rmt_view.py
+++ b/app/views/rmt_view.py
@@ -23,7 +23,7 @@ def get_employee_tabs(employee_information, current_job_role, device_information
                          'ONS Mobile Number': device_number,
                          'Status': employee_information['status']}
 
-    if employee_information['mobileStaff']:
+    if employee_information[4:7] == "MOB":
         mobile_staff = 'Yes'
     else:
         mobile_staff = 'No'


### PR DESCRIPTION
Should fix issue with all staff showing as mobile users, as now the roleID is analysed and if the characters "MOB" are in the correct location then it will assign the user "mobile"